### PR TITLE
Include photo URLs in CSV export

### DIFF
--- a/lib/children/basic-exporter/index.js
+++ b/lib/children/basic-exporter/index.js
@@ -91,7 +91,7 @@ function pullData(surveyId, filter, done) {
   var tmpFile = TMPDIR + '/' + uuid.v1();
 
   // Start with some basic headers
-  var headers = ['object_id', 'address', 'collector', 'timestamp', 'source', 'lat', 'long'];
+  var headers = ['object_id', 'address', 'collector', 'timestamp', 'source', 'lat', 'long', 'photos'];
 
   // Record which header is at which index
   var headerIndices = {};
@@ -174,7 +174,8 @@ function pullData(surveyId, filter, done) {
       item.properties.created.toISOString(), // Convert the date to ISO8601 format
       item.properties.source.type,
       item.properties.centroid[1],
-      item.properties.centroid[0]
+      item.properties.centroid[0],
+      item.properties.files
     ];
 
     // Add info subfields


### PR DESCRIPTION
A customer requested seeing presence of a photo or not in the CSV export. I think it's more general to just include the photo URL. In Excel you should still be able to fairly easily filter to rows that have an entry there or have no entry there.

Using centroid instead of lat/long makes it harder to use our exports with other random mapping tools, and it's also a potentially overly technical term.

/cc @hampelm 
