### PR TITLE
Avoid periods in field names to stay compliant

### DIFF
--- a/lib/children/basic-exporter/geojson-stream.js
+++ b/lib/children/basic-exporter/geojson-stream.js
@@ -38,10 +38,10 @@ GeoJSONStream.prototype._transform = function transform(item, encoding, done) {
   }
 
   // Flatten the response fields
-  flatten(item.properties, 'responses', 'r.');
+  flatten(item.properties, 'responses', 'r_');
 
   // Flatten the info fields
-  flatten(item.properties, 'info', 'i.');
+  flatten(item.properties, 'info', 'i_');
 
   if (item.properties.files && item.properties.files.length > 0) {
     item.properties.photo = item.properties.files[0];


### PR DESCRIPTION
ArcMap will load shapefiles that have dots in the field names, but it will choke trying to bring up the attributes table. Using underscores keeps us safe.

/cc @hampelm 
