### PR TITLE
Use a group query for metadata

### DIFF
--- a/lib/children/basic-exporter/index.js
+++ b/lib/children/basic-exporter/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var EventEmitter = require('events').EventEmitter;
 var fs = require('fs');
 var stream = require('stream');
 var util = require('util');
@@ -20,7 +19,6 @@ var mongo = require('./mongo');
 // TODO: we reference this in a couple of projects. Should we split the
 // Mongoose model definitions out to a separate module?
 var Response = require('./Response');
-var RowStream = require('./row-stream');
 var shapefile = require('./shapefile');
 var SQLiteStream = require('./sqlite-stream');
 
@@ -37,7 +35,6 @@ if (mode === undefined) {
 var surveyId = data.survey;
 var s3Object = data.s3Object;
 var bucket = data.bucket;
-var uploadPrefix = 'http://' + bucket + '.s3.amazonaws.com/';
 // Used for Shapefile export
 var name = data.name;
 var timezone = data.timezone;
@@ -73,60 +70,91 @@ function throttle(func, period) {
 // fields to their maximum arity, and the maximum number of files linked by an
 // entry.
 function getMetadata(surveyId, done) {
-  var docStream = Response
-  .find({ 'properties.survey': surveyId})
-  .select({ entries: 1, properties: 1})
-  .stream();
+  Response.collection.group(
+    {},
+    { 'properties.survey': surveyId },
+    {
+      infoFields: {},
+      responseArity: {},
+      fileCount: 0
+    },
+    function reduce (doc, memo) {
+      var k;
+      var entry;
+      for (k = 0; k < doc.entries.length; k += 1) {
+        entry = doc.entries[k];
 
-  var info = {};
-  var maxFileCount = 0;
-  var responseArity = {};
+        // File count
+        var files = entry.files;
+        if (files) {
+          var fileCount = files.length;
+          if (fileCount > memo.fileCount) {
+            memo.fileCount = fileCount;
+          }
+        }
 
-  docStream.on('error', done);
-  docStream.on('end', function () {
-    done(null, [Object.keys(info), Object.keys(responseArity), responseArity, maxFileCount]);
-  });
+        // Response field arity
+        var fields;
+        if (entry.responses) {
+          fields = Object.keys(entry.responses);
+        } else {
+          fields = [];
+        }
+        var i;
+        var len = fields.length;
+        var field;
+        var value;
+        for (i = 0; i < len; i += 1) {
+          field = fields[i];
+          value = entry.responses[field];
 
-  function processEntry(entry) {
-    var files = entry.files;
-    if (files) {
-      var fileCount = files.length;
-      if (fileCount > maxFileCount) {
-        maxFileCount = fileCount;
+          var max = memo.responseArity[field];
+
+          if (max === undefined) {
+            max = 0;
+          }
+
+          var arity = 1;
+
+          if (Object.prototype.toString.call(value) === '[object Array]') {
+            arity = value.length;
+          }
+
+          if (arity > max) {
+            memo.responseArity[field] = arity;
+          }
+        }
+      }
+
+      // Info fields
+      if (doc.properties.info) {
+        var keys = Object.keys(doc.properties.info);
+        for (k = 0; k < keys.length; k += 1) {
+          memo.infoFields[keys[k]] = true;
+        }
+      }
+    }, function (error, docs) {
+      if (error) {
+        console.log(error);
+        done(error);
+        return;
+      }
+
+      var doc;
+
+      if (docs && docs.length > 0) {
+        doc = docs[0];
+        done(null, [
+          Object.keys(doc.infoFields),
+          Object.keys(doc.responseArity),
+          doc.responseArity,
+          doc.fileCount
+        ]);
+      } else {
+        done(null, [[], [], {}, 0]);
       }
     }
-
-    var fields = _.keys(entry.responses);
-    var i;
-    var len = fields.length;
-    var field;
-    var value;
-    for (i = 0; i < len; i += 1) {
-      field = fields[i];
-      value = entry.responses[field];
-
-      var max = responseArity[field];
-
-      if (max === undefined) {
-        max = 0;
-      }
-
-      var arity = 1;
-
-      if (Object.prototype.toString.call(value) === '[object Array]') {
-        arity = value.length;
-      }
-
-      if (arity > max) {
-        responseArity[field] = arity;
-      }
-    }
-  }
-
-  docStream.on('data', function (doc) {
-    info = _.merge(info, doc.properties.info);
-    _.each(doc.entries, processEntry);
-  });
+  );
 }
 
 function EntryStream(options) {
@@ -157,13 +185,6 @@ EntryStream.prototype._transform = function transform(chunk, encoding, done) {
   done();
 };
 
-function pushBlanks(row, count) {
-  var i;
-  for (i = 0; i < count; i += 1) {
-    row.push('');
-  }
-}
-
 /**
 * Get raw data for the survey and return a stream of entry objects.
 *
@@ -174,9 +195,6 @@ function pushBlanks(row, count) {
 * entry for each response item.
 */
 function getEntryStream(surveyId, filter) {
-  var tmpFile = makeTempPath();
-
-
   var entryStream = new EntryStream({
     filter: filter
   });
@@ -336,24 +354,23 @@ async.series([
     var entryStream = getEntryStream(surveyId, filter);
 
     var converter;
-    var tmpSQLite;
 
     if (mode === 'csv') {
       converter = new CSVStream({
-        timezone: data.timezone,
+        timezone: timezone,
         infoFields: infoFields,
         responseFields: responseFields,
         responseArity: responseArity
       });
     } else if (mode === 'kml') {
       converter = new KMLStream({
-        timezone: data.timezone,
+        timezone: timezone,
         infoFields: infoFields,
         responseFields: responseFields
       });
     } else if (mode === 'sqlite') {
       converter = fakeSQLiteConverter({
-        timezone: data.timezone,
+        timezone: timezone,
         infoFields: infoFields,
         responseFields: responseFields,
         fileCount: fileCount
@@ -361,7 +378,7 @@ async.series([
     } else if (mode === 'shapefile') {
       converter = fakeShapefileConverter({
         name: name,
-        timezone: data.timezone,
+        timezone: timezone,
         infoFields: infoFields,
         responseFields: responseFields,
         fileCount: fileCount


### PR DESCRIPTION
For large surveys, we save significant time by doing this processing on the database. For a test survey of ~75k entries, the metadata step went from the range of 45-48 seconds down to about 6 seconds.

/cc @hampelm 
