### PR TITLE
Escape commas in header rows

### DIFF
--- a/lib/children/basic-exporter/csv.js
+++ b/lib/children/basic-exporter/csv.js
@@ -23,20 +23,33 @@ function CSVStream(options) {
 
 util.inherits(CSVStream, stream.Transform);
 
+
+function escapeCommas(val) {
+  // Check if we need to escape the value
+  if (val.indexOf(',') !== -1) {
+    return '"' + val + '"';
+  }
+
+  return val;
+}
+
 CSVStream.prototype._headerString = function () {
   var arr = coreFields;
   var index = arr.length;
   var i;
 
+  // Add the metadata headers (eg created, surveyor name)
   for (i = 0; i < this.infoFields.length; i += 1) {
     arr[index] = this.infoFields[i];
     index += 1;
   }
 
+  // Add the response answer headers
   for (i = 0; i < this.responseFields.length; i += 1) {
-    arr[index] = this.responseFields[i];
+    arr[index] = escapeCommas(this.responseFields[i]);
     index += 1;
   }
+
   return arr.join(',') + '\n';
 };
 
@@ -48,9 +61,7 @@ function clean(val) {
 
   // Check if we need to escape the value
   var str = String(val);
-  if (str.indexOf(',') !== -1) {
-    return '"' + str + '"';
-  }
+  val = escapeCommas(str);
 
   return val;
 }


### PR DESCRIPTION
We need to make sure that commas in header rows of the CSV are escaped. 

I created the `escapeCommas` function because I assume that, since it's so simple, it will be inlined and therefore not have a significant performance impact. I haven't tested this assumption. 
