### PR TITLE
Split data by geometry type for shapefile export

### DIFF
--- a/lib/children/basic-exporter/index.js
+++ b/lib/children/basic-exporter/index.js
@@ -7,13 +7,15 @@ var util = require('util');
 var _ = require('lodash');
 var async = require('async');
 var concat = require('concat-stream');
+var duplexify = require('duplexify');
 var knox = require('knox');
 var minimist = require('minimist');
+var Promise = require('bluebird');
+var through2 = require('through2');
 var uuid = require('uuid');
 var xml2js = require('xml2js');
 
 var CSVStream = require('./csv');
-var duplexify = require('duplexify');
 var KMLStream = require('./kml');
 var mongo = require('./mongo');
 // TODO: we reference this in a couple of projects. Should we split the
@@ -21,6 +23,8 @@ var mongo = require('./mongo');
 var Response = require('./Response');
 var shapefile = require('./shapefile');
 var SQLiteStream = require('./sqlite-stream');
+
+Promise.promisifyAll(fs);
 
 var argv = minimist(process.argv.slice(2));
 var data = JSON.parse(argv._[0]);
@@ -65,6 +69,14 @@ function throttle(func, period) {
     }, period);
     func.apply(this, arguments);
   };
+}
+
+function promisifyStreamEnd(stream) {
+  return new Promise(function (resolve, reject) {
+    stream.on('error', reject);
+    stream.on('end', resolve);
+    stream.on('finish', resolve);
+  });
 }
 
 // For this dataset, get a list of all info fields, a mapping of all response
@@ -304,10 +316,66 @@ function fakeSQLiteConverter(options, postprocessor) {
   return converter;
 }
 
-function fakeShapefileConverter(options) {
-  return fakeSQLiteConverter(options, function (filename) {
-    return shapefile.convert(filename, makeTempPath(), options.name);
+function filterGeometries(types) {
+  return through2.obj(function (chunk, enc, done) {
+    if (_.contains(types, chunk.geometry.type)) {
+      this.push(chunk);
+    }
+    done();
   });
+}
+
+function fakeShapefileConverter(options) {
+  var converter = duplexify();
+
+  // Create a a temporary sqlite file for each geometry type.
+  var pointTmp = makeTempPath();
+  var lineStringTmp = makeTempPath();
+  var polygonTmp = makeTempPath();
+  var pointStream = new SQLiteStream(_.defaults({ filename: pointTmp }, options));
+  var lineStringStream = new SQLiteStream(_.defaults({ filename: lineStringTmp }, options));
+  var polygonStream = new SQLiteStream(_.defaults({ filename: polygonTmp }, options));
+
+  var distributor = through2.obj();
+  converter.setWritable(distributor);
+  converter._writableState.objectMode = true;
+
+  distributor.pipe(filterGeometries(['Point', 'MultiPoint'])).pipe(pointStream);
+  distributor.pipe(filterGeometries(['LineString', 'MultiLineString'])).pipe(lineStringStream);
+  distributor.pipe(filterGeometries(['Polygon', 'MultiPolygon'])).pipe(polygonStream);
+
+  // Wait for the SQLite conversion to finish.
+  Promise.join(
+    promisifyStreamEnd(pointStream),
+    promisifyStreamEnd(lineStringStream),
+    promisifyStreamEnd(polygonStream)
+  ).then(function () {
+    // Pass the array of files to the shapefile converter, which will add all
+    // resulting files to a ZIP archive.
+    var files = [ pointTmp, lineStringTmp, polygonTmp ];
+    var read = shapefile.convert(files, makeTempPath(), [
+      options.name + '_point',
+      options.name + '_linestring',
+      options.name + '_polygon'
+    ]);
+
+    // Use the resulting readable stream as duplexify's readable half.
+    converter.setReadable(read);
+
+    // Remove the temporary files when the read stream has ended.
+    read.on('end', function () {
+      // TODO: use a through stream, so we can wait for the unlinks to finish
+      // before emitting 'end' on the readable part of duplexify? The chance of
+      // this causing a problem is low right now.
+      Promise.map(files, fs.unlink.bind(fs))
+      .catch(function (error) {
+        converter.emit('error', error);
+      });
+    });
+  }).catch(function (error) {
+    converter.emit('error', error);
+  });
+  return converter;
 }
 
 var output;
@@ -398,11 +466,15 @@ async.series([
     entryStream.pipe(converter).pipe(output)
     .on('finish', next)
     .on('error', next);
+
+    converter.on('error', function (error) {
+      output.emit('error', error);
+    });
   },
   // Store the export on S3
   function (next) {
     var stats = fs.statSync(filename);
-    console.log('event=worker_info at=basic_exporter temp_file_size=' + stats.size);
+    console.log('event=worker_info at=basic_exporter export_file_size=' + stats.size);
     storeRemoteData(filename, s3Object, next);
   },
   // Remove the temporary file
@@ -414,6 +486,7 @@ async.series([
   // TODO: report failure vs. success to the worker management infrastructure.
   if (error) {
     console.log(error);
+    console.log(error.stack);
   }
 
   process.send({
@@ -423,4 +496,3 @@ async.series([
 
   process.exit(0);
 });
-

--- a/lib/children/basic-exporter/shapefile.js
+++ b/lib/children/basic-exporter/shapefile.js
@@ -3,8 +3,6 @@
 
 var childProcess = require('child_process');
 var fs = require('fs');
-var stream = require('stream');
-var util = require('util');
 
 var archiver = require('archiver');
 var Promise = require('bluebird');
@@ -13,49 +11,53 @@ var qfs = require('q-io/fs');
 Promise.promisifyAll(fs);
 Promise.promisifyAll(childProcess);
 
-var TMPDIR;
-
 var OGRCMD = 'ogr2ogr -s_srs "EPSG:4326" -t_srs "EPSG:4326" -f "ESRI Shapefile" ';
 
-exports.convert = function convert(geoJSONFile, outdir, outname) {
+function promisifyStreamEnd(stream) {
+  return new Promise(function (resolve, reject) {
+    stream.on('error', reject);
+    stream.on('end', resolve);
+    stream.on('finish', resolve);
+  });
+}
+
+exports.convert = function convert(sourceFiles, outdir, layerNames) {
   var zip = archiver('zip');
 
   // Make the temporary directory
   fs.mkdirAsync(outdir)
   .then(function () {
+    return sourceFiles;
+  }).map(function (input, i) {
     // Run the ogr2ogr command
-    var cmd = OGRCMD + outdir + '/' + outname + '.shp ' + geoJSONFile;
+    // TODO: upgrade the geometries to Multi-geometries, so we don't run into
+    // conflicts between Polygon nand MultiPolygon, for example.
+    var cmd = OGRCMD + outdir + '/' + layerNames[i] + '.shp ' + input;
     console.log('running command: ' + cmd);
     return childProcess.execAsync(cmd, {
       env: process.env
     });
-  })
-  .spread(function (stdout, stderr) {
-    // Gather the names of the files created by ogr2ogr.
-
-    // XXX improve logging
-    console.log(stdout);
-    console.log(stderr);
-
-    // Return a promise for the file names
-    return fs.readdirAsync(outdir);
-  })
-  .then(function (files) {
+  }, {
+    concurrency: 2
+  }).map(function (pipes) {
+    // TODO: improve logging
+    console.log(pipes[0]);
+    console.log(pipes[1]);
+  }).then(function () {
     // Add files to the zip stream.
-    files.forEach(function (name) {
-      zip.append(fs.createReadStream(outdir + '/' + name), { name : name });
-    });
-
-    // Finalize the zip stream.
-    return Promise.promisify(zip.finalize, zip)()
-    .then(function (count) {
-      // XXX improve logging
-      console.log('Wrote ' + count + ' bytes to the ZIP archive.');
-      // Remove temporary directory
-      return Promise.resolve(qfs.removeTree(outdir));
-    });
-  })
-  .catch(function (error) {
+    zip.bulk([{
+      expand: true,
+      cwd: outdir,
+      src: '*'
+    }]);
+  }).then(function () {
+    var promise = promisifyStreamEnd(zip);
+    zip.finalize();
+    return promise;
+  }).then(function () {
+    // Remove temporary directory
+    return Promise.resolve(qfs.removeTree(outdir));
+  }).catch(function (error) {
     zip.emit('error', error);
   });
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "sqlite3": "^3.0.2",
     "duplexify": "^3.2.0",
     "wellknown": "^0.3.0",
-    "concat-stream": "^1.4.6"
+    "concat-stream": "^1.4.6",
+    "through2": "^0.6.3"
   }
 }


### PR DESCRIPTION
Runs ogr2ogr on temporary sqlite files, even if they don't have any data. That's not ideal, but it simplifies the stream processing. There will only be a `.shp` file when the layer actually has rows, though.

/cc @hampelm 